### PR TITLE
Expose SAM attention flags via CLI

### DIFF
--- a/models/builder.py
+++ b/models/builder.py
@@ -58,6 +58,12 @@ class EncoderDecoder(nn.Module):
             backbone_kwargs["sam_use_topk"] = getattr(cfg, "sam_use_topk", True)
             backbone_kwargs["sam_top_m"] = getattr(cfg, "sam_top_m", 5)
             backbone_kwargs["superpower"] = getattr(cfg, "superpower", False)
+            backbone_kwargs["sam_decoder_use_cosine"] = getattr(cfg, "sam_decoder_use_cosine", True)
+            backbone_kwargs["sam_decoder_learnable_temp"] = getattr(cfg, "sam_decoder_learnable_temp", True)
+            backbone_kwargs["sam_decoder_logit_init"] = getattr(cfg, "sam_decoder_logit_init", 1 / 0.07)
+            backbone_kwargs["sam_encoder_use_cosine"] = getattr(cfg, "sam_encoder_use_cosine", False)
+            backbone_kwargs["sam_encoder_learnable_temp"] = getattr(cfg, "sam_encoder_learnable_temp", False)
+            backbone_kwargs["sam_encoder_logit_init"] = getattr(cfg, "sam_encoder_logit_init", 1.0)
 
         self.backbone = backbone(**backbone_kwargs)
         self.aux_head = None
@@ -75,7 +81,10 @@ class EncoderDecoder(nn.Module):
                                                               sam_use_topk=getattr(cfg, "sam_use_topk", True),
                                                               sam_top_m=getattr(cfg, "sam_top_m", 5),
                                                               backbone_num_heads=getattr(self.backbone, "num_heads",
-                                                                                         [4, 4, 8, 16]))
+                                                                                         [4, 4, 8, 16]),
+                                                              sam_decoder_use_cosine=getattr(cfg, "sam_decoder_use_cosine", True),
+                                                              sam_decoder_learnable_temp=getattr(cfg, "sam_decoder_learnable_temp", True),
+                                                              sam_decoder_logit_init=getattr(cfg, "sam_decoder_logit_init", 1 / 0.07))
             if cfg.aux_rate != 0:
                 from .decoders.fcnhead import FCNHead
                 self.aux_index = 2
@@ -101,6 +110,9 @@ class EncoderDecoder(nn.Module):
                 in_index=[1, 2, 3],
                 norm_cfg=norm_cfg,
                 channels=cfg.decoder_embed_dim,
+                sam_decoder_use_cosine=getattr(cfg, "sam_decoder_use_cosine", True),
+                sam_decoder_learnable_temp=getattr(cfg, "sam_decoder_learnable_temp", True),
+                sam_decoder_logit_init=getattr(cfg, "sam_decoder_logit_init", 1 / 0.07),
             )
             from .decoders.fcnhead import FCNHead
             if cfg.aux_rate != 0:

--- a/models/decoders/ham_head.py
+++ b/models/decoders/ham_head.py
@@ -111,6 +111,9 @@ class LightHamSAMHead(BaseDecodeHead):
         enable_sam=True,
         sam_use_topk=True,
         sam_top_m=5,
+        sam_decoder_use_cosine: bool = True,
+        sam_decoder_learnable_temp: bool = True,
+        sam_decoder_logit_init: float = 1 / 0.07,
         **kwargs,
     ):
         super().__init__(input_transform="multiple_select", **kwargs)
@@ -139,6 +142,9 @@ class LightHamSAMHead(BaseDecodeHead):
                 attn_drop=0.0,
                 proj_drop=0.0,
                 ffn_drop=0.0,
+                decoder_use_cosine=sam_decoder_use_cosine,
+                decoder_learnable_temp=sam_decoder_learnable_temp,
+                decoder_logit_scale_init=sam_decoder_logit_init,
             )
 
         # 原汉堡块与对齐层保持不变

--- a/models/decoders/hsg_head.py
+++ b/models/decoders/hsg_head.py
@@ -38,6 +38,9 @@ class HierarchicalSemanticGuidedHead(BaseDecodeHead):
                  sam_use_topk=True,
                  sam_top_m=5,
                  backbone_num_heads=(4, 4, 8, 16),
+                 sam_decoder_use_cosine: bool = True,
+                 sam_decoder_learnable_temp: bool = True,
+                 sam_decoder_logit_init: float = 1 / 0.07,
                  **kwargs):
         super().__init__(in_channels=in_channels,
                          in_index=in_index,
@@ -73,6 +76,9 @@ class HierarchicalSemanticGuidedHead(BaseDecodeHead):
                         num_heads=self.backbone_num_heads[global_idx],
                         alpha_init=0.05,
                         attn_drop=0.0, proj_drop=0.0, ffn_drop=0.0,
+                        decoder_use_cosine=sam_decoder_use_cosine,
+                        decoder_learnable_temp=sam_decoder_learnable_temp,
+                        decoder_logit_scale_init=sam_decoder_logit_init,
                     )
                 )
             else:

--- a/models/encoders/DFormerv2.py
+++ b/models/encoders/DFormerv2.py
@@ -412,6 +412,12 @@ class dformerv2(nn.Module):
         sam_top_m=5,
         superpower: bool = False,
         sam_enc_gamma_scale: float = 1.0,
+        sam_decoder_use_cosine: bool = True,
+        sam_decoder_learnable_temp: bool = True,
+        sam_decoder_logit_init: float = 1 / 0.07,
+        sam_encoder_use_cosine: bool = False,
+        sam_encoder_learnable_temp: bool = False,
+        sam_encoder_logit_init: float = 1.0,
     ):
         super().__init__()
         self.out_indices = out_indices
@@ -470,6 +476,12 @@ class dformerv2(nn.Module):
                 top_m=sam_top_m,
                 num_heads=self.num_heads[i],  # ★ 传该 stage 的头数
                 gamma_scale=sam_enc_gamma_scale,
+                decoder_use_cosine=sam_decoder_use_cosine,
+                decoder_learnable_temp=sam_decoder_learnable_temp,
+                decoder_logit_scale_init=sam_decoder_logit_init,
+                encoder_use_cosine=sam_encoder_use_cosine,
+                encoder_learnable_temp=sam_encoder_learnable_temp,
+                encoder_logit_scale_init=sam_encoder_logit_init,
             )
 
             for i in range(self.num_layers)
@@ -492,6 +504,12 @@ class dformerv2(nn.Module):
                         top_m=sam_top_m,
                         num_heads=self.num_heads[i],  # 同一 stage 的头数
                         gamma_scale=sam_enc_gamma_scale,
+                        decoder_use_cosine=sam_decoder_use_cosine,
+                        decoder_learnable_temp=sam_decoder_learnable_temp,
+                        decoder_logit_scale_init=sam_decoder_logit_init,
+                        encoder_use_cosine=sam_encoder_use_cosine,
+                        encoder_learnable_temp=sam_encoder_learnable_temp,
+                        encoder_logit_scale_init=sam_encoder_logit_init,
                     )
                     for _ in range(num_units)
                 ])

--- a/train.sh
+++ b/train.sh
@@ -12,6 +12,8 @@ echo "Hugging Face cache has been set to: ${HF_HOME}"
 export CUDA_VISIBLE_DEVICES="0,1"
 export TORCHDYNAMO_VERBOSE=1
 
+EXTRA_ARGS=("$@")
+
 PYTHONPATH="$(dirname $0)/..":"$(dirname $0)":$PYTHONPATH \
     torchrun \
     --nnodes=$NNODES \
@@ -35,6 +37,7 @@ PYTHONPATH="$(dirname $0)/..":"$(dirname $0)":$PYTHONPATH \
     --pad_SUNRGBD \
     --no-use_seed \
     --superpower \
+    "${EXTRA_ARGS[@]}"
 
 # --text-source imglabels \
 # 文本来源：labels / captions / both / imglabels

--- a/utils/train.py
+++ b/utils/train.py
@@ -65,6 +65,34 @@ parser.add_argument("--sam-enc-stages", type=str, default="0,1,2,3", help="Comma
 parser.add_argument("--sam-dec-stages", type=str, default="0,1,2,3", help="Comma separated, e.g., 1,3")
 parser.add_argument("--superpower", default=False, action=argparse.BooleanOptionalAction)
 
+# --- SAM temperature & attention styles ---
+parser.add_argument(
+    "--sam-decoder-use-cosine",
+    dest="sam_decoder_use_cosine",
+    default=None,
+    action=argparse.BooleanOptionalAction,
+)
+parser.add_argument(
+    "--sam-decoder-learnable-temp",
+    dest="sam_decoder_learnable_temp",
+    default=None,
+    action=argparse.BooleanOptionalAction,
+)
+parser.add_argument("--sam-decoder-logit-init", type=float, default=None)
+parser.add_argument(
+    "--sam-encoder-use-cosine",
+    dest="sam_encoder_use_cosine",
+    default=None,
+    action=argparse.BooleanOptionalAction,
+)
+parser.add_argument(
+    "--sam-encoder-learnable-temp",
+    dest="sam_encoder_learnable_temp",
+    default=None,
+    action=argparse.BooleanOptionalAction,
+)
+parser.add_argument("--sam-encoder-logit-init", type=float, default=None)
+
 # os.environ['MASTER_PORT'] = '169710'
 torch.set_float32_matmul_precision("high")
 import torch._dynamo
@@ -166,6 +194,20 @@ with Engine(custom_parser=parser) as engine:
         config.sam_enc_stages = _parse_stages(args.sam_enc_stages)
         config.sam_dec_stages = _parse_stages(args.sam_dec_stages)
         config.superpower = bool(getattr(args, "superpower", False))
+
+        # === SAM temperature & attention styles ===
+        if args.sam_decoder_use_cosine is not None:
+            config.sam_decoder_use_cosine = bool(args.sam_decoder_use_cosine)
+        if args.sam_decoder_learnable_temp is not None:
+            config.sam_decoder_learnable_temp = bool(args.sam_decoder_learnable_temp)
+        if args.sam_decoder_logit_init is not None:
+            config.sam_decoder_logit_init = float(args.sam_decoder_logit_init)
+        if args.sam_encoder_use_cosine is not None:
+            config.sam_encoder_use_cosine = bool(args.sam_encoder_use_cosine)
+        if args.sam_encoder_learnable_temp is not None:
+            config.sam_encoder_learnable_temp = bool(args.sam_encoder_learnable_temp)
+        if args.sam_encoder_logit_init is not None:
+            config.sam_encoder_logit_init = float(args.sam_encoder_logit_init)
 
         logger = get_logger(config.log_dir, config.log_file, rank=engine.local_rank)
         # check if pad_SUNRGBD is used correctly


### PR DESCRIPTION
## Summary
- add CLI arguments in `utils/train.py` so SAM encoder/decoder cosine vs. dot-product and temperature scaling can be toggled at runtime
- allow `train.sh` to forward arbitrary extra arguments to `utils/train.py`, enabling the new SAM switches from the shell script

## Testing
- python -m compileall models utils

------
https://chatgpt.com/codex/tasks/task_e_69099560eb948330876c40c80281855d